### PR TITLE
Support for Gnome 3.16

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -610,18 +610,6 @@ const TimeTracker = new Lang.Class({
         GLib.timeout_add_seconds(0, 5, this.onUpdateTimeout, this);
         GLib.timeout_add_seconds(1, this.settings.get_int('save-interval'), this.onSaveTimeout, this);
         GLib.timeout_add_seconds(2, this.settings.get_int('notify-interval'), this.onNotifyTimeout, this);
-
-        //register shortcut
-        Main.wm.addKeybinding(
-            "show-search-shortcut",
-            this.settings,
-            Meta.KeyBindingFlags.NONE,
-            Shell.KeyBindingMode.NORMAL | Shell.KeyBindingMode.MESSAGE_TRAY | Shell.KeyBindingMode.OVERVIEW,
-            Lang.bind(this, function() {
-                timeTracker.menu.open();
-                timeTracker.showSearch();
-            })
-        );
     },
 
     updateActiveIssueLabel: function(){

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.10", "3.11", "3.12", "3.14"],
+    "shell-version": ["3.10", "3.11", "3.12", "3.14", "3.16"],
     "uuid": "redmine_time_tracker@undef.ch",
     "name": "Redmine Time Tracker",
     "description": "Integrated time tracking for redmine",


### PR DESCRIPTION
I'm not an expert in writing gnome shell extensions, but it looks like the method to add a keybinding `Main.wm.addKeybinding` does not work with gnome 3.16 anymore. After removing the call to the API for adding the keybinding, the extension also works with gnome 3.16.

Before the change the popup does not show any issues and the following error was written in the logfile.

    gnome-session[1380]: (gnome-shell:1453): Gjs-WARNING **: JS ERROR: Exception in callback for signal: activate: TypeError: timeTracker is undefined
    gnome-session[1380]: TimeTracker<._init/<@/home/shempel/.local/share/gnome-shell/extensions/redmine_time_tracker@undef.ch/extension.js:554

